### PR TITLE
Добавление управления пользовательскими списками Shikimori

### DIFF
--- a/api/user-rates.js
+++ b/api/user-rates.js
@@ -1,0 +1,51 @@
+export default async function handler(req, res) {
+  try {
+    const auth = req.headers.authorization || ''
+    if (!auth.startsWith('Bearer ')) {
+      res.statusCode = 401
+      return res.json({ error: 'No bearer token' })
+    }
+    const url = new URL(req.url, 'http://localhost')
+    if (req.method === 'GET') {
+      const userId = url.searchParams.get('user_id')
+      const r = await fetch(`https://shikimori.one/api/users/${userId}/anime_rates`, {
+        headers: { Authorization: auth }
+      })
+      const data = await r.json()
+      res.statusCode = r.status
+      res.setHeader('Content-Type', 'application/json')
+      return res.end(JSON.stringify(data))
+    }
+    let body = ''
+    req.on('data', c => body += c)
+    await new Promise(resolve => req.on('end', resolve))
+    if (req.method === 'POST') {
+      const r = await fetch('https://shikimori.one/api/v2/user_rates', {
+        method: 'POST',
+        headers: { Authorization: auth, 'Content-Type': 'application/json' },
+        body
+      })
+      const data = await r.json()
+      res.statusCode = r.status
+      res.setHeader('Content-Type', 'application/json')
+      return res.end(JSON.stringify(data))
+    }
+    if (req.method === 'PUT') {
+      const id = url.searchParams.get('id')
+      const r = await fetch(`https://shikimori.one/api/v2/user_rates/${id}`, {
+        method: 'PUT',
+        headers: { Authorization: auth, 'Content-Type': 'application/json' },
+        body
+      })
+      const data = await r.json()
+      res.statusCode = r.status
+      res.setHeader('Content-Type', 'application/json')
+      return res.end(JSON.stringify(data))
+    }
+    res.statusCode = 405
+    res.end('Method not allowed')
+  } catch (e) {
+    res.statusCode = 500
+    res.end(JSON.stringify({ error: String(e.message || e) }))
+  }
+}

--- a/src/components/Animes/Animes.vue
+++ b/src/components/Animes/Animes.vue
@@ -9,14 +9,20 @@
           <img class="anime__poster" loading="lazy" :src="anime.poster?.originalUrl || fallback"
             :alt="anime.russian || anime.name" />
           <router-link class="button anime__watch" :to="`/watch/${anime.id}`">Смотреть</router-link>
-          <div class="dropdown">
-            <button class="button anime__list" @click="toggleStatus">Добавить в список</button>
+          <div class="dropdown" v-if="auth.isLoggedIn">
+            <button class="button anime__list" @click="toggleStatus">{{ currentStatusLabel || 'Добавить в список' }}</button>
             <ul v-if="showStatus" class="dropdown__menu">
-              <li v-for="s in statusOptions" :key="s" class="dropdown__item" @click="selectStatus(s)">
-                {{ s }}
+              <li
+                v-for="s in statusOptions"
+                :key="s.value"
+                class="dropdown__item"
+                @click="selectStatus(s.value)"
+              >
+                {{ s.label }}
               </li>
             </ul>
           </div>
+          <button v-else class="button anime__list" @click="auth.login">Войти</button>
         </div>
 
         <!-- общая сетка для правой колонки -->
@@ -87,6 +93,8 @@ import { ref, watch, computed } from 'vue'
 import { useRoute } from 'vue-router'
 import { fetchAnimeById } from '@/scripts/fetchAnimeById'
 import DOMPurify from 'dompurify'
+import { useAuthStore } from '@/stores/auth'
+import { useListsStore } from '@/stores/lists'
 
 const route = useRoute()
 const anime = ref(null)
@@ -96,21 +104,34 @@ const fallback = '/placeholder.jpg'
 
 const showStatus = ref(false)
 const statusOptions = [
-  'Запланировано',
-  'Просмотрено',
-  'Брошено',
-  'Пересматриваю',
-  'Отложено',
-  'Смотрю'
+  { label: 'Запланировано', value: 'planned' },
+  { label: 'Просмотрено', value: 'completed' },
+  { label: 'Брошено', value: 'dropped' },
+  { label: 'Пересматриваю', value: 'rewatching' },
+  { label: 'Отложено', value: 'on_hold' },
+  { label: 'Смотрю', value: 'watching' }
 ]
+const auth = useAuthStore()
+const lists = useListsStore()
 
 function toggleStatus() {
   showStatus.value = !showStatus.value
 }
 
-function selectStatus() {
+function selectStatus(val) {
   showStatus.value = false
+  if (!anime.value) return
+  lists.setStatus(anime.value.id, val)
 }
+
+const currentStatus = computed(() => {
+  if (!anime.value) return null
+  return lists.rateFor(anime.value.id)?.status || null
+})
+const currentStatusLabel = computed(() => {
+  const s = statusOptions.find(o => o.value === currentStatus.value)
+  return s ? s.label : null
+})
 
 async function load(id) {
   loading.value = true

--- a/src/components/Profile/Profile.vue
+++ b/src/components/Profile/Profile.vue
@@ -9,25 +9,51 @@
     <div v-else>
       <a href="/api/auth/login" class="profile-page__login">Войти</a>
     </div>
+    <div v-if="auth.isLoggedIn" class="profile-page__lists">
+      <div v-for="(items, status) in groupedLists" :key="status" class="profile-page__list">
+        <h2 class="profile-page__list-title">{{ statusLabels[status] || status }}</h2>
+        <ul class="profile-page__animes">
+          <li v-for="r in items" :key="r.id" class="profile-page__anime">
+            <router-link :to="`/animes/${r.anime.id}`">{{ r.anime.russian || r.anime.name }}</router-link>
+          </li>
+        </ul>
+      </div>
+    </div>
   </section>
 </template>
 
 <script setup>
-import { computed } from 'vue';
-import { useAuthStore } from '@/stores/auth';
+import { computed, onMounted } from 'vue'
+import { useAuthStore } from '@/stores/auth'
+import { useListsStore } from '@/stores/lists'
 
-const auth = useAuthStore();
-console.log(auth.user);
+const auth = useAuthStore()
+const lists = useListsStore()
 
 const avatarUrl = computed(() => {
-  const img = auth.user?.image?.x48 || auth.user?.avatar;
-  if (!img) return '';
-  return img.startsWith('http') ? img : `https://shikimori.one${img}`;
-});
+  const img = auth.user?.image?.x48 || auth.user?.avatar
+  if (!img) return ''
+  return img.startsWith('http') ? img : `https://shikimori.one${img}`
+})
+
+const statusLabels = {
+  planned: 'Запланировано',
+  completed: 'Просмотрено',
+  dropped: 'Брошено',
+  rewatching: 'Пересматриваю',
+  on_hold: 'Отложено',
+  watching: 'Смотрю'
+}
+
+const groupedLists = computed(() => lists.grouped)
+
+onMounted(() => {
+  if (auth.isLoggedIn && !lists.rates.length) lists.fetchRates()
+})
 
 const logout = () => {
-  window.location.href = '/api/auth/logout';
-};
+  window.location.href = '/api/auth/logout'
+}
 
 </script>
 
@@ -64,6 +90,30 @@ const logout = () => {
     background: red;
     color: #fff;
     font-weight: 700;
+  }
+
+  &__lists {
+    margin-top: 40px;
+    display: grid;
+    gap: 32px;
+  }
+
+  &__list-title {
+    margin: 0 0 12px;
+    font-size: 22px;
+  }
+
+  &__animes {
+    list-style: none;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  &__anime a {
+    color: #fff;
+    text-decoration: none;
   }
 }
 </style>

--- a/src/stores/auth.js
+++ b/src/stores/auth.js
@@ -1,5 +1,6 @@
 // /src/stores/auth.js
 import { defineStore } from 'pinia'
+import { useListsStore } from './lists'
 const TOKEN_KEY = 'shiki_access_token'
 
 export const useAuthStore = defineStore('auth', {
@@ -26,6 +27,7 @@ export const useAuthStore = defineStore('auth', {
       this.token = null
       this.user = null
       try { localStorage.removeItem(TOKEN_KEY) } catch {}
+      try { useListsStore().$reset() } catch {}
     },
 
     // ЕДИНСТВЕННЫЙ fetchMe (подтягивает профиль и сбрасывает флаги)
@@ -39,6 +41,7 @@ export const useAuthStore = defineStore('auth', {
         })
         if (!r.ok) throw new Error(`whoami ${r.status}`)
         this.user = await r.json()
+        try { useListsStore().fetchRates() } catch {}
       } catch (e) {
         this.error = String(e?.message || e)
         this.clearToken()

--- a/src/stores/lists.js
+++ b/src/stores/lists.js
@@ -1,0 +1,76 @@
+import { defineStore } from 'pinia'
+import { useAuthStore } from './auth'
+
+export const useListsStore = defineStore('lists', {
+  state: () => ({
+    rates: [],
+    loading: false,
+    error: null
+  }),
+  getters: {
+    rateFor: s => id => s.rates.find(r => r.target_id === id),
+    grouped: s => s.rates.reduce((acc, r) => {
+      (acc[r.status] = acc[r.status] || []).push(r)
+      return acc
+    }, {})
+  },
+  actions: {
+    async fetchRates() {
+      const auth = useAuthStore()
+      if (!auth.token || !auth.user) return
+      this.loading = true
+      this.error = null
+      try {
+        const r = await fetch(`/api/user-rates?user_id=${auth.user.id}`, {
+          headers: { Authorization: `Bearer ${auth.token}` }
+        })
+        if (!r.ok) throw new Error(`rates ${r.status}`)
+        this.rates = await r.json()
+      } catch (e) {
+        this.error = String(e.message || e)
+        this.rates = []
+      } finally {
+        this.loading = false
+      }
+    },
+    async setStatus(animeId, status) {
+      const auth = useAuthStore()
+      if (!auth.token || !auth.user) return
+      const existing = this.rates.find(r => r.target_id === animeId)
+      try {
+        if (existing) {
+          const r = await fetch(`/api/user-rates?id=${existing.id}`, {
+            method: 'PUT',
+            headers: {
+              Authorization: `Bearer ${auth.token}`,
+              'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({ status })
+          })
+          if (!r.ok) throw new Error(`update ${r.status}`)
+          const data = await r.json()
+          existing.status = data.status
+        } else {
+          const r = await fetch('/api/user-rates', {
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${auth.token}`,
+              'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+              user_id: auth.user.id,
+              target_id: animeId,
+              target_type: 'Anime',
+              status
+            })
+          })
+          if (!r.ok) throw new Error(`create ${r.status}`)
+          const data = await r.json()
+          this.rates.push(data)
+        }
+      } catch (e) {
+        console.error(e)
+      }
+    }
+  }
+})


### PR DESCRIPTION
## Summary
- Добавлен стор списков и API-прокси для получения и изменения `user_rates`
- Интегрирован выбор статусов и добавление тайтлов в Animes.vue
- На странице профиля выводятся списки пользователя

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c1627a14888326b35287e551a79d9e