### PR TITLE
Улучшение работы со списками и профилем

### DIFF
--- a/src/components/Animes/Animes.vue
+++ b/src/components/Animes/Animes.vue
@@ -87,7 +87,7 @@
 </template>
 
 <script setup>
-import { ref, watch, computed } from 'vue'
+import { ref, watch, computed, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
 import { fetchAnimeById } from '@/scripts/fetchAnimeById'
 import DOMPurify from 'dompurify'
@@ -112,6 +112,14 @@ const statusOptions = [
 const auth = useAuthStore()
 const lists = useListsStore()
 
+onMounted(() => {
+  if (auth.isLoggedIn && !lists.rates.length) lists.fetchRates()
+})
+
+watch(() => auth.isLoggedIn, val => {
+  if (val && !lists.rates.length) lists.fetchRates()
+})
+
 function toggleStatus() {
   showStatus.value = !showStatus.value
 }
@@ -119,7 +127,7 @@ function toggleStatus() {
 function selectStatus(val) {
   showStatus.value = false
   if (!anime.value) return
-  lists.setStatus(anime.value.id, val)
+  lists.setStatus(anime.value, val)
 }
 
 function removeStatus() {

--- a/src/components/Profile/Profile.vue
+++ b/src/components/Profile/Profile.vue
@@ -39,7 +39,7 @@
   </template>
 
 <script setup>
-import { computed, onMounted } from 'vue'
+import { computed, onMounted, watch } from 'vue'
 import { useAuthStore } from '@/stores/auth'
 import { useListsStore } from '@/stores/lists'
 
@@ -66,6 +66,10 @@ const fallback = '/placeholder.jpg'
 
 onMounted(() => {
   if (auth.isLoggedIn && !lists.rates.length) lists.fetchRates()
+})
+
+watch(() => auth.isLoggedIn, val => {
+  if (val && !lists.rates.length) lists.fetchRates()
 })
 
 const logout = () => {

--- a/src/stores/lists.js
+++ b/src/stores/lists.js
@@ -34,9 +34,10 @@ export const useListsStore = defineStore('lists', {
         this.loading = false
       }
     },
-    async setStatus(animeId, status) {
+    async setStatus(anime, status) {
       const auth = useAuthStore()
       if (!auth.token || !auth.user) return
+      const animeId = typeof anime === 'object' ? anime.id : anime
       const existing = this.rates.find(r => r.target_id === animeId)
       try {
         if (existing) {
@@ -67,7 +68,8 @@ export const useListsStore = defineStore('lists', {
           })
           if (!r.ok) throw new Error(`create ${r.status}`)
           const data = await r.json()
-          this.rates.push(data)
+          const animeObj = typeof anime === 'object' ? anime : null
+          this.rates.push(animeObj ? { ...data, anime: animeObj } : data)
         }
       } catch (e) {
         console.error(e)


### PR DESCRIPTION
## Изменения
- Добавлен предварительный запрос списка тайтлов и наблюдение за авторизацией на странице тайтла
- Исправлено сохранение аниме при добавлении в пользовательский список
- На странице профиля добавлено отслеживание авторизации для загрузки списков

## Тестирование
- `npm test` (ошибка: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c16aae2bc88326890c8262f12f8998