### PR TITLE
Исправить отображение статусов и постеров в списках

### DIFF
--- a/src/components/Animes/Animes.vue
+++ b/src/components/Animes/Animes.vue
@@ -138,7 +138,7 @@ function removeStatus() {
 
 const currentStatus = computed(() => {
   if (!anime.value) return null
-  return lists.rateFor(anime.value.id)?.status || null
+  return lists.rateFor(Number(anime.value.id))?.status || null
 })
 const currentStatusLabel = computed(() => {
   const s = statusOptions.find(o => o.value === currentStatus.value)

--- a/src/components/Profile/Profile.vue
+++ b/src/components/Profile/Profile.vue
@@ -20,7 +20,7 @@
               :to="`/animes/${r.anime.id}`"
               :title="r.anime.russian || r.anime.name"
               :style="{
-                backgroundImage: `linear-gradient(0deg, rgba(0,0,0,.55), rgba(0,0,0,.55)), url(${r.anime.poster?.originalUrl || fallback})`,
+                backgroundImage: `linear-gradient(0deg, rgba(0,0,0,.55), rgba(0,0,0,.55)), url(${r.anime.image?.original || fallback})`,
                 backgroundSize: '100% 100%, cover',
                 backgroundPosition: 'center, center',
                 backgroundRepeat: 'no-repeat, no-repeat'

--- a/src/stores/lists.js
+++ b/src/stores/lists.js
@@ -8,7 +8,10 @@ export const useListsStore = defineStore('lists', {
     error: null
   }),
   getters: {
-    rateFor: s => id => s.rates.find(r => r.target_id === id),
+    rateFor: s => id => {
+      const animeId = Number(id)
+      return s.rates.find(r => r.target_id === animeId)
+    },
     grouped: s =>
       s.rates.reduce((acc, r) => {
         (acc[r.status] = acc[r.status] || []).push(r)
@@ -35,7 +38,7 @@ export const useListsStore = defineStore('lists', {
           if (data.length < LIMIT) break
           page++
         }
-        this.rates = all
+        this.rates = all.map(r => ({ ...r, target_id: Number(r.target_id) }))
       } catch (e) {
         this.error = String(e.message || e)
         this.rates = []
@@ -46,7 +49,7 @@ export const useListsStore = defineStore('lists', {
     async setStatus(anime, status) {
       const auth = useAuthStore()
       if (!auth.token || !auth.user) return
-      const animeId = typeof anime === 'object' ? anime.id : anime
+      const animeId = Number(typeof anime === 'object' ? anime.id : anime)
       const existing = this.rates.find(r => r.target_id === animeId)
       try {
         if (existing) {
@@ -78,7 +81,9 @@ export const useListsStore = defineStore('lists', {
           if (!r.ok) throw new Error(`create ${r.status}`)
           const data = await r.json()
           const animeObj = typeof anime === 'object' ? anime : null
-          this.rates.push(animeObj ? { ...data, anime: animeObj } : data)
+          this.rates.push(
+            animeObj ? { ...data, anime: animeObj, target_id: animeId } : { ...data, target_id: animeId }
+          )
         }
       } catch (e) {
         console.error(e)
@@ -87,7 +92,8 @@ export const useListsStore = defineStore('lists', {
     async remove(animeId) {
       const auth = useAuthStore()
       if (!auth.token || !auth.user) return
-      const existing = this.rates.find(r => r.target_id === animeId)
+      const idNum = Number(animeId)
+      const existing = this.rates.find(r => r.target_id === idNum)
       if (!existing) return
       try {
         const r = await fetch(`/api/user-rates?id=${existing.id}`, {


### PR DESCRIPTION
## Изменения
- корректно определять статус тайтла в списках пользователя
- показывать постеры в карточках профиля

## Тестирование
- `npm test` (ошибка: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68c1710503e88326a8e4bd87533e690b